### PR TITLE
Add role variation support and localized role names

### DIFF
--- a/src/types/contributors.ts
+++ b/src/types/contributors.ts
@@ -3,11 +3,13 @@ export type FeaturedContributor = {
   roleIds: string[], // refers to ID from 'roles' collection
 }
 
-type ContributorReservedKeys = 'id' | 'slug' | 'website' | 'profileRoleIds' | 'defaultDocumentRoleIds' | 'createdAt' | 'updatedAt';
+type ContributorReservedKeys = 'id' | 'slug' | 'website' | 'profileRoleIds' | 'defaultDocumentRoleIds' | 'roleVariationPreference' | 'createdAt' | 'updatedAt';
 
 type ContributorBase<SupportedLanguageCodeType extends string | number | symbol> = {
   [key in Exclude<SupportedLanguageCodeType, ContributorReservedKeys>]?: string;
 };
+
+export type ContributorRoleVariationKey = 'm' | 'f' | 'nb' | 'other';
 
 export type Contributor<SupportedLanguageCodeType extends string | number | symbol, TimestampLike = unknown> = {
   en: string;
@@ -16,9 +18,17 @@ export type Contributor<SupportedLanguageCodeType extends string | number | symb
   website?: string; // Website URL
   profileRoleIds?: string[];
   defaultDocumentRoleIds?: string[];
+  roleVariationPreference?: ContributorRoleVariationKey;
   createdAt: TimestampLike;
   updatedAt: TimestampLike;
 } & ContributorBase<SupportedLanguageCodeType>;
+
+export type ContributorRoleNameVariations = Partial<{ [key in ContributorRoleVariationKey]: string }>;
+
+type ContributorRoleLocalized = {
+  name: string,
+  variations?: ContributorRoleNameVariations,
+};
 
 export type ContributorRole<SupportedLanguageCodeType extends string | number | symbol, TimestampLike = unknown> = {
   id: string,
@@ -29,8 +39,8 @@ export type ContributorRole<SupportedLanguageCodeType extends string | number | 
   profileOnly?: boolean,
   createdAt: TimestampLike,
   updatedAt: TimestampLike,
-  en: { name: string },
-} & Omit<Partial<{ [key in SupportedLanguageCodeType]: { name: string } }>, 'en'>;
+  en: ContributorRoleLocalized,
+} & Omit<Partial<{ [key in SupportedLanguageCodeType]: ContributorRoleLocalized }>, 'en'>;
 
 export type ContributorStrings<SupportedLanguageCodeType extends string | number | symbol, TimestampLike = unknown> = {
   // The language code is the document ID, but we must store it in the document as well.


### PR DESCRIPTION
Add per-language name variations (m/f/nb/other) to ContributorRole and a roleVariationPreference field on Contributor to select which variation applies. Add profileRoleIds and defaultDocumentRoleIds to Contributor.