### PR TITLE
Add hasImage prop to Contributor

### DIFF
--- a/src/types/contributors.ts
+++ b/src/types/contributors.ts
@@ -19,6 +19,7 @@ export type Contributor<SupportedLanguageCodeType extends string | number | symb
   profileRoleIds?: string[];
   defaultDocumentRoleIds?: string[];
   roleVariationPreference?: ContributorRoleVariationKey;
+  hasImage?: boolean;
   createdAt: TimestampLike;
   updatedAt: TimestampLike;
 } & ContributorBase<SupportedLanguageCodeType>;


### PR DESCRIPTION
Add `hasImage` prop to `Contributor` type. We are using it on the web app to determine whether to attempt to load the image for the contributor.